### PR TITLE
Refactor report generation with topic bundling

### DIFF
--- a/create_report.py
+++ b/create_report.py
@@ -1,84 +1,223 @@
+import os
 import json
 from datetime import datetime
+from typing import List, Dict
+import re
 
-import openai
-import config
+from openai import OpenAI
+
+from env_bootstrap import boot
+from utils_logging import setup_logger, print_runtime_diag, utc_now_iso
+from market_snapshot import get_snapshot, snapshot_to_md
+from news_fetch import fetch_topic, Article, RECENT_DAYS
+from report_renderer import render_market_section, render_topic_section, render_briefs
+
+from topics_list import MACRO_KEYWORDS as DEFAULT_TOPICS
+
+# -------- 基础配置 --------
+TOPICS = DEFAULT_TOPICS
+
+APPEND_STALE = True
+MAX_TOP_SECTIONS = 10
 
 
-client = openai.OpenAI(api_key=config.OPENAI_API_KEY)
+def _date_from_url(url: str):
+    m = re.search(r"/(20\d{2})[-/](\d{2})[-/](\d{2})/", url)
+    if m:
+        return f"{m.group(1)}-{m.group(2)}-{m.group(3)}"
+    return None
 
 
-def get_market_insights():
-    """Call OpenAI API to fetch latest market insights and return as dict."""
-    instruction = (
-        """核心指令一：洞察抓取指令
-作为一名专业的宏观经济数据分析助手，请抓取并整理今日全球市场的关键信息。\n"
-        "请以JSON格式返回，包含以下字段：\n"
-        "- global_markets: 全球主要股票市场指数的涨跌情况;\n"
-        "- commodities: 重要大宗商品价格及变化;\n"
-        "- forex: 主要货币对的走势;\n"
-        "- economic_events: 当日需要关注的重大经济事件或数据发布。\n"
-        """
+def _openai_client():
+    return OpenAI()  # 读取 .env 中的 OPENAI_API_KEY
+
+
+# create_report.py（仅替换 _summarize_points）
+def _summarize_points(client: OpenAI, model: str, topic: str, articles: List[Article]) -> Dict[str, str]:
+    sys_prompt = (
+        "You are a macro analyst. You MUST ONLY use facts explicitly present in the items. "
+        "Do NOT invent entities/numbers. If a required figure is missing in all items, write 'not stated'. "
+        "Prefer concrete numbers with units and dates (e.g., 'cut 25bp to 5.25%-5.50% on 2025-09-18')."
+    )
+
+    bullets = []
+    for a in articles[:3]:
+        d = a.published_at.date().isoformat() if a.published_at else "n/a"
+        snippet = (a.text or "")[:600].replace("\n", " ").strip()
+        bullets.append(f"- date:{d} | src:{a.source} | title:{a.title} | url:{a.url} | text:{snippet}")
+
+    user_prompt = (
+        f"Topic: {topic}\n"
+        "From ONLY the list below, extract a concise brief in JSON with EXACT keys: what, so_what, who, watch.\n"
+        "- In 'what', include the key quantitative facts if present (e.g., size of move in bp, previous vs new level, effective date).\n"
+        "- If numbers/levels are not in the texts, say 'not stated'.\n\n"
+        + "\n".join(bullets)
+    )
+
+    resp = client.chat.completions.create(
+        model=model,
+        temperature=0.0,
+        response_format={"type": "json_object"},
+        messages=[{"role": "system", "content": sys_prompt},
+                  {"role": "user", "content": user_prompt}],
     )
     try:
-        response = client.chat.completions.create(
-            model="gpt-4o",
-            messages=[
-                {"role": "system", "content": "You are a financial data assistant."},
-                {"role": "user", "content": instruction},
-            ],
-        )
-        content = response.choices[0].message.content
-        try:
-            return json.loads(content)
-        except json.JSONDecodeError:
-            print("解析JSON失败：API返回的数据不是有效的JSON。")
-            return None
-    except Exception as err:
-        print(f"调用OpenAI接口失败：{err}")
-        return None
+        data = json.loads(resp.choices[0].message.content)
+        bad = not data or sum(1 for k in ("what", "so_what", "who", "watch") if not data.get(k)) >= 3
+        if bad:
+            return {
+                "what": "Insufficient facts",
+                "so_what": "Insufficient facts",
+                "who": "Insufficient facts",
+                "watch": "Insufficient facts",
+            }
+        return data
+    except Exception:
+        return {
+            "what": "Insufficient facts",
+            "so_what": "Insufficient facts",
+            "who": "Insufficient facts",
+            "watch": "Insufficient facts",
+        }
 
 
-def compose_report(insights_data):
-    """Generate macroeconomic report from insights_data."""
-    instruction_template = (
-        """核心指令二：报告生成指令
-请根据以下JSON数据撰写一份结构完整、语言专业的每日宏观经济报告：\n
-[此处将插入由第一个指令生成的JSON数据]\n
-要求：\n1. 先概述整体市场情绪；\n2. 分模块分析股票市场、大宗商品、外汇等；\n3. 结合经济事件给出后市展望。\n"""
+def main():
+    # 环境与日志
+    dotenv_path = boot()
+    logger = setup_logger()
+    print_runtime_diag(dotenv_path)
+    model = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+
+    logger.info("== Morning Report started ==")
+    logger.info(f"UTC now: {utc_now_iso()}  | MODEL: {model}")
+
+    # 市场快照
+    snapshot = get_snapshot()
+    snapshot_md = snapshot_to_md(snapshot)
+
+    client = _openai_client()
+    LLM_USED = False
+    appendix_items = []
+
+    bundles = []
+    engine_stats = {"topics": 0, "recent_used": 0, "stale_used": 0}
+
+    for topic in TOPICS:
+        logger.info(f"Collecting for topic: {topic}")
+        buckets = fetch_topic(topic)  # {"recent": [...], "stale":[...]}
+        recent = buckets["recent"]
+        stale = buckets["stale"]
+
+        engine_stats["topics"] += 1
+        engine_stats["recent_used"] += len(recent)
+        engine_stats["stale_used"] += len(stale)
+
+        # 按 score 排序（高→低）
+        recent_sorted = sorted(recent, key=lambda a: getattr(a, "score", 0), reverse=True)
+        topic_score = getattr(recent_sorted[0], "score", 0) if recent_sorted else 0
+
+        bundles.append({
+            "topic": topic,
+            "recent_sorted": recent_sorted,
+            "stale": stale,
+            "topic_score": topic_score,
+        })
+
+    # --- 统一排序 & 只取 Top-10 ---
+    bundles.sort(key=lambda b: b["topic_score"], reverse=True)
+    selected = bundles[:MAX_TOP_SECTIONS]
+
+    sections = []
+    appendix_items = []
+
+    for b in selected:
+        topic = b["topic"]
+        recent_sorted = b["recent_sorted"]
+        stale = b["stale"]
+
+        # Deep/Short 二选一
+        if len(recent_sorted) >= 2:
+            top_articles = recent_sorted[:2]
+            summary = _summarize_points(client, model, topic, top_articles)
+            if "Insufficient" not in "".join(summary.values()):
+                LLM_USED = True
+                sections.append(
+                    render_topic_section(
+                        f"{topic} (Deep)",
+                        [a.title for a in top_articles],
+                        summary,
+                    )
+                )
+            else:
+                for a in top_articles:
+                    appendix_items.append({
+                        "title": a.title,
+                        "url": a.url,
+                        "date": (a.published_at.date().isoformat() if a.published_at else _date_from_url(a.url)),
+                        "label": a.source,
+                    })
+
+        elif len(recent_sorted) == 1:
+            one = recent_sorted[:1]
+            summary = _summarize_points(client, model, topic, one)
+            if "Insufficient" not in "".join(summary.values()):
+                LLM_USED = True
+                sections.append(
+                    render_topic_section(
+                        f"{topic} (Short)",
+                        [a.title for a in one],
+                        summary,
+                    )
+                )
+            else:
+                a = one[0]
+                appendix_items.append({
+                    "title": a.title,
+                    "url": a.url,
+                    "date": (a.published_at.date().isoformat() if a.published_at else _date_from_url(a.url)),
+                    "label": a.source,
+                })
+        else:
+            if APPEND_STALE:
+                for a in stale[:3]:
+                    appendix_items.append({
+                        "title": a.title,
+                        "url": a.url,
+                        "date": (a.published_at.date().isoformat() if a.published_at else _date_from_url(a.url)),
+                        "label": a.source,
+                    })
+
+    # 其余未入选 Top-10 的主题，也把部分链接丢到 Briefs（可选）
+    for b in bundles[MAX_TOP_SECTIONS:]:
+        extras = []
+        extras.extend(b["recent_sorted"][:2])
+        if APPEND_STALE:
+            extras.extend(b["stale"][:2])
+        for a in extras:
+            appendix_items.append({
+                "title": a.title,
+                "url": a.url,
+                "date": (a.published_at.date().isoformat() if a.published_at else _date_from_url(a.url)),
+                "label": a.source,
+            })
+
+    # Assemble markdown
+    md_parts = []
+    md_parts.append("# Daily Macro Morning Brief\n")
+    md_parts.append(render_market_section(snapshot_md))
+    md_parts.extend(sections)
+    md_parts.append(render_briefs(appendix_items))
+
+    out_name = f"Macro_Report_{datetime.utcnow().date().isoformat()}.md"
+    with open(out_name, "w", encoding="utf-8") as f:
+        f.write("\n\n".join(md_parts))
+
+    logger.info(
+        f"[SUMMARY] LLM_USED={LLM_USED} | topics={engine_stats['topics']} | "
+        f"recent_used={engine_stats['recent_used']} | stale_used={engine_stats['stale_used']}"
     )
-    filled_instruction = instruction_template.replace(
-        "[此处将插入由第一个指令生成的JSON数据]",
-        json.dumps(insights_data, ensure_ascii=False, indent=2),
-    )
-    try:
-        response = client.chat.completions.create(
-            model="gpt-4o",
-            messages=[
-                {"role": "system", "content": "你是一名资深的宏观经济分析师。"},
-                {"role": "user", "content": filled_instruction},
-            ],
-        )
-        return response.choices[0].message.content.strip()
-    except Exception as err:
-        print(f"生成报告时发生错误：{err}")
-        return None
+    logger.info(f"Report written to: {out_name}")
 
 
 if __name__ == "__main__":
-    print("---[ 开始生成每日宏观经济报告 ]---")
-    print("[1/3] 正在获取市场最新洞察...")
-    data = get_market_insights()
-    if data is None:
-        print("获取市场洞察失败，程序终止。")
-        raise SystemExit(1)
-    print("[2/3] 洞察已获取，正在撰写分析报告...")
-    report = compose_report(data)
-    if report is None:
-        print("生成报告失败，程序终止。")
-        raise SystemExit(1)
-    today = datetime.now().strftime("%Y-%m-%d")
-    filename = f"Macro_Report_{today}.md"
-    with open(filename, "w", encoding="utf-8") as f:
-        f.write(report)
-    print(f"[3/3] 报告生成完毕！已保存至文件: {filename}")
+    main()


### PR DESCRIPTION
## Summary
- refactor the report pipeline to collect topic bundles first, rank by score, and render only the top sections
- ensure topic sections choose between Deep or Short coverage and push the rest to briefs
- tighten the summarization prompt to prioritize explicit quantitative facts or mark them as not stated

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cceb8b441c83328b265560d1a62af7